### PR TITLE
support non-versioned buckets

### DIFF
--- a/lib/ex_aws/s3/utils.ex
+++ b/lib/ex_aws/s3/utils.ex
@@ -177,9 +177,15 @@ defmodule ExAws.S3.Utils do
       },
       expiration: %{
         tag: "Expiration",
-        action_tags: fn %{expired_object_delete_marker: marker} ->
-          marker = if marker, do: "true", else: "false"
-          [["<ExpiredObjectDeleteMarker>", marker, "</ExpiredObjectDeleteMarker>"]]
+        action_tags: fn params ->
+          case params do
+            %{expired_object_delete_marker: marker} ->
+              marker = if marker, do: "true", else: "false"
+              [["<ExpiredObjectDeleteMarker>", marker, "</ExpiredObjectDeleteMarker>"]]
+
+            _ ->
+              []
+          end
         end
       },
       noncurrent_version_transition: %{

--- a/test/lib/s3/utils_test.exs
+++ b/test/lib/s3/utils_test.exs
@@ -37,37 +37,65 @@ defmodule ExAws.S3.ImplTest do
              }
   end
 
-  test "build_lifecycle_rule" do
-    rule = %{
-      id: "123",
-      enabled: true,
-      filter: %{
-        prefix: "prefix/",
-        tags: %{}
-      },
-      actions: %{
-        transition: %{
-          trigger: {:days, 2},
-          storage: ""
+  describe "build_lifecycle_rule" do
+    test "applying rule to unversioned buckets" do
+      rule = %{
+        id: "123",
+        enabled: true,
+        filter: %{
+          prefix: "prefix/",
+          tags: %{}
         },
-        expiration: %{
-          trigger: {:days, 2},
-          expired_object_delete_marker: true
-        },
-        noncurrent_version_transition: %{
-          trigger: {:days, 2},
-          storage: ""
-        },
-        noncurrent_version_expiration: %{
-          trigger: {:days, 2}
-        },
-        abort_incomplete_multipart_upload: %{
-          trigger: {:days, 2}
+        actions: %{
+          transition: %{
+            trigger: {:days, 2},
+            storage: ""
+          },
+          expiration: %{
+            trigger: {:days, 2}
+          },
+          abort_incomplete_multipart_upload: %{
+            trigger: {:days, 2}
+          }
         }
       }
-    }
 
-    assert rule |> Utils.build_lifecycle_rule() ==
-             "<Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>2</DaysAfterInitiation></AbortIncompleteMultipartUpload><NoncurrentVersionExpiration><NoncurrentDays>2</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><NoncurrentDays>2</NoncurrentDays><StorageClass></StorageClass></NoncurrentVersionTransition><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Transition><Days>2</Days><StorageClass></StorageClass></Transition><Filter><Prefix>prefix/</Prefix></Filter><Status>Enabled</Status><ID>123</ID></Rule>"
+      assert rule |> Utils.build_lifecycle_rule() ==
+               "<Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>2</DaysAfterInitiation></AbortIncompleteMultipartUpload><Expiration><Days>2</Days></Expiration><Transition><Days>2</Days><StorageClass></StorageClass></Transition><Filter><Prefix>prefix/</Prefix></Filter><Status>Enabled</Status><ID>123</ID></Rule>"
+    end
+
+    test "applying rule to versioned buckets" do
+      rule = %{
+        id: "123",
+        enabled: true,
+        filter: %{
+          prefix: "prefix/",
+          tags: %{}
+        },
+        actions: %{
+          transition: %{
+            trigger: {:days, 2},
+            storage: ""
+          },
+          expiration: %{
+            trigger: {:days, 2},
+            expired_object_delete_marker: true
+          },
+          noncurrent_version_transition: %{
+            trigger: {:days, 2},
+            storage: ""
+          },
+          noncurrent_version_expiration: %{
+            trigger: {:days, 2}
+          },
+          abort_incomplete_multipart_upload: %{
+            trigger: {:days, 2}
+          }
+        }
+      }
+
+      assert rule |> Utils.build_lifecycle_rule() ==
+               "<Rule><AbortIncompleteMultipartUpload><DaysAfterInitiation>2</DaysAfterInitiation></AbortIncompleteMultipartUpload><NoncurrentVersionExpiration><NoncurrentDays>2</NoncurrentDays></NoncurrentVersionExpiration><NoncurrentVersionTransition><NoncurrentDays>2</NoncurrentDays><StorageClass></StorageClass></NoncurrentVersionTransition><Expiration><Days>2</Days><ExpiredObjectDeleteMarker>true</ExpiredObjectDeleteMarker></Expiration><Transition><Days>2</Days><StorageClass></StorageClass></Transition><Filter><Prefix>prefix/</Prefix></Filter><Status>Enabled</Status><ID>123</ID></Rule>"
+    end
   end
 end


### PR DESCRIPTION
## Description of the change
ex_aws_s3 only handled writing lifecycles for versioned buckets. I have added some code so the writer is not dependent on receiving an ExpiredObjectDeleteMarker in the data.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [X] Technical Debt
- [ ] Documentation

## Related tickets
https://app.shortcut.com/active-prospect/story/40202/fix-aws-ex-s3-lifecycle-permissions-handling

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [x]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [x]  This branch has been rebased off master to be current.

### Tracking 
- [x]  Issue from Shortcut has a link to this pull request.
- [x]  This PR has a link to the issue in Shortcut.

### QA
- [x]  This branch has been deployed to staging and tested.
